### PR TITLE
Use rpath for all libraries

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,7 +34,7 @@ set(SUBPROJECT_CMAKE_ARGS
 set(BOOST_B2_USER_CONFIG "${OPENMW_DEPS_BINARY_DIR}/boost-user-config.jam")
 set(BOOST_DARWIN_PATCH "${OPENMW_DEPS_BINARY_DIR}/boost.patch")
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/boost-user-config.jam.in" ${BOOST_B2_USER_CONFIG})
-configure_file("${CMAKE_CURRENT_SOURCE_DIR}/boost.patch.in" ${BOOST_DARWIN_PATCH} @ONLY)
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/boost.patch" ${BOOST_DARWIN_PATCH} COPYONLY)
 
 if (CMAKE_BUILD_TYPE EQUAL "Debug")
   set(BOOST_VARIANT "debug")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -149,6 +149,9 @@ ExternalProject_Add(
   CMAKE_ARGS ${MYGUI_CMAKE_ARGS}
 )
 
+set(SDL2_POSTBUILD_SCRIPT "${OPENMW_DEPS_BINARY_DIR}/SDL2-postbuild.sh")
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/SDL2-postbuild.sh" ${SDL2_POSTBUILD_SCRIPT} COPYONLY)
+
 ExternalProject_Add(
   SDL2
   URL https://libsdl.org/release/SDL2-2.0.5.tar.gz
@@ -156,7 +159,7 @@ ExternalProject_Add(
 
   SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/SDL2
   CONFIGURE_COMMAND ${CONFIGURE_WRAPPER} ${CMAKE_CURRENT_SOURCE_DIR}/SDL2/configure --prefix=${CMAKE_INSTALL_PREFIX} --without-x
-  BUILD_COMMAND make
+  BUILD_COMMAND make COMMAND sh ${SDL2_POSTBUILD_SCRIPT}
 )
 
 set(OSG_CMAKE_ARGS

--- a/src/SDL2-postbuild.sh
+++ b/src/SDL2-postbuild.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+find . -type f -name '*.dylib' | xargs -I {} sh -c 'echo "-id @rpath/$(basename {}) {}"' | xargs install_name_tool

--- a/src/boost.patch
+++ b/src/boost.patch
@@ -6,7 +6,7 @@ diff --git a/tools/build/src/tools/darwin.jam b/tools/build/src/tools/darwin.jam
  actions link.dll bind LIBRARIES
  {
 -    "$(CONFIG_COMMAND)" -dynamiclib -Wl,-single_module -install_name "$(<:B)$(<:S)" -L"$(LINKPATH)" -o "$(<)" "$(>)" "$(LIBRARIES)" -l$(FINDLIBS-SA) -l$(FINDLIBS-ST) $(FRAMEWORK_PATH) -framework$(_)$(FRAMEWORK:D=:S=) $(OPTIONS) $(USER_OPTIONS)
-+    "$(CONFIG_COMMAND)" -dynamiclib -Wl,-single_module -install_name "@CMAKE_INSTALL_PREFIX@/lib/$(<:B)$(<:S)" -L"$(LINKPATH)" -o "$(<)" "$(>)" "$(LIBRARIES)" -l$(FINDLIBS-SA) -l$(FINDLIBS-ST) $(FRAMEWORK_PATH) -framework$(_)$(FRAMEWORK:D=:S=) $(OPTIONS) $(USER_OPTIONS)
++    "$(CONFIG_COMMAND)" -dynamiclib -Wl,-single_module -install_name "@rpath/$(<:B)$(<:S)" -L"$(LINKPATH)" -o "$(<)" "$(>)" "$(LIBRARIES)" -l$(FINDLIBS-SA) -l$(FINDLIBS-ST) $(FRAMEWORK_PATH) -framework$(_)$(FRAMEWORK:D=:S=) $(OPTIONS) $(USER_OPTIONS)
  }
 
  # We use libtool instead of ar to support universal binary linking


### PR DESCRIPTION
- [x] boost: https://svn.boost.org/trac/boost/attachment/ticket/5343/remove-rpath.patch
- [x] SDL2

Fixes #17.
